### PR TITLE
興味・登録ページの入力をチェックボックスに変更

### DIFF
--- a/app/routes/editInterestTags.tsx
+++ b/app/routes/editInterestTags.tsx
@@ -1,5 +1,11 @@
-import { Button, Input, Box, Heading, VStack } from "@chakra-ui/react";
-import { useState } from "react";
+import {
+  Button,
+  Box,
+  Heading,
+  VStack,
+  Checkbox, // v3ではこれは名前空間(Namespace)として機能します
+  SimpleGrid,
+} from "@chakra-ui/react";
 import {
   Form,
   redirect,
@@ -10,6 +16,22 @@ import {
 import { addInterestTag } from "~/models/user.server";
 import { requireUser } from "~/services/auth.server";
 
+// タグの候補リスト
+const CANDIDATE_TAGS = [
+  "スマート農業",
+  "AI",
+  "初心者",
+  "センサー",
+  "IoT",
+  "市場分析",
+  "害虫対策",
+  "ドローン",
+  "有機栽培",
+  "経営管理",
+  "自動化",
+  "ロボット",
+];
+
 export async function loader({ request }: LoaderFunctionArgs) {
   await requireUser(request);
   return {};
@@ -18,15 +40,15 @@ export async function loader({ request }: LoaderFunctionArgs) {
 export async function action({ request }: ActionFunctionArgs) {
   const user = await requireUser(request);
   const formData = await request.formData();
-  const tags = formData.get("tags") as string;
-  const tagList = tags.split(",").map((s) => s.trim());
-  await addInterestTag(user.id, tagList);
+
+  // 選択されたすべての "tags" の値を配列として取得
+  const tags = formData.getAll("tags") as string[];
+
+  await addInterestTag(user.id, tags);
   return redirect("/mypage");
 }
 
 export default function EditInterestTagsPage() {
-  const [tags, setTags] = useState("");
-
   return (
     <Box
       maxW="400px"
@@ -37,30 +59,54 @@ export default function EditInterestTagsPage() {
       borderRadius="xl"
       boxShadow="lg"
     >
-      {/* 中央寄せのカードボックス */}
       <Heading size="md" mb={4}>
         興味のあるタグを登録・編集
       </Heading>
-      {/* 見出し */}
+
       <Form method="post">
-        {/* フォームの submit を handleSubmit に接続 */}
-        <VStack gap={4}>
-          {/* 縦に並べるレイアウト（間隔4）,spacing -> gap（CSSのgap） */}
-          <Input
-            placeholder="例: スマート農業,AI,初心者,センサー" // プレースホルダの例
-            value={tags} // Input の値を state と連動
-            onChange={(e) => setTags(e.target.value)} // 入力変更時に state を更新
-            name="tags"
-          />
+        <VStack gap={4} align="stretch">
+          <Box
+            p={4}
+            borderWidth="1px"
+            borderRadius="md"
+            maxH="300px"
+            overflowY="auto"
+          >
+            {/* 修正点1: spacing -> gap に変更 */}
+            <SimpleGrid columns={2} gap={3}>
+              {CANDIDATE_TAGS.map((tag) => (
+                // 修正点2: v3用のカスタムCheckboxコンポーネントを使用
+                <CustomCheckbox key={tag} value={tag} label={tag} />
+              ))}
+            </SimpleGrid>
+          </Box>
+
           <Button
-            type="submit" // submit ボタン
-            colorScheme="teal" // カラースキーム
-            loadingText="保存中" // ローディング時のテキスト
+            type="submit"
+            colorPalette="teal" // 修正点3: colorScheme -> colorPalette (v3推奨)
+            loadingText="保存中"
+            width="full"
           >
             保存する
           </Button>
         </VStack>
       </Form>
     </Box>
+  );
+}
+
+// ------------------------------------------
+// Chakra UI v3 用のチェックボックス部品
+// ------------------------------------------
+function CustomCheckbox({ value, label }: { value: string; label: string }) {
+  return (
+    <Checkbox.Root name="tags" value={value} colorPalette="teal">
+      <Checkbox.HiddenInput />
+      <Checkbox.Control>
+        {/* チェックが入ったときのアイコン（チェックマーク） */}
+        <Checkbox.Indicator />
+      </Checkbox.Control>
+      <Checkbox.Label>{label}</Checkbox.Label>
+    </Checkbox.Root>
   );
 }


### PR DESCRIPTION
興味登録ページにおいて、今のように自由に記入できる形だと、「あ」や「さ」などの一文字だけの無意味なInterestTagsも登録できてしまうため、チェックボックスで登録するように変更しました(リストの内容自体は適宜変更する)。