### PR TITLE
mypageの興味の欄の追加と興味登録機能の修正

### DIFF
--- a/app/models/user.server.ts
+++ b/app/models/user.server.ts
@@ -11,7 +11,8 @@ export async function addInterestTag(id: User["id"], tags: string[]) {
     where: { id },
     data: {
       InterestTag: {
-        connect: tags.map((tag) => ({ tag })),
+        // connect ではなく set を使用することで、既存の関連をリセットして新しいリストに置き換える
+        set: tags.map((tag) => ({ tag })),
       },
     },
   });
@@ -22,7 +23,10 @@ export type UserWithAvatar = Prisma.UserGetPayload<{
 }>;
 
 export async function getUserById(id: User["id"]) {
-  return prisma.user.findUnique({ where: { id }, include: { avatar: true } });
+  return prisma.user.findUnique({
+    where: { id },
+    include: { avatar: true, InterestTag: true },
+  });
 }
 
 export async function getUserByEmail(email: User["email"]) {

--- a/app/routes/editInterestTags.tsx
+++ b/app/routes/editInterestTags.tsx
@@ -9,17 +9,22 @@ import {
 import {
   Form,
   redirect,
+  useLoaderData,
   type ActionFunctionArgs,
   type LoaderFunctionArgs,
 } from "react-router";
 
 import { farmKeyword } from "~/data/farmKeyword";
-import { addInterestTag } from "~/models/user.server";
+import { addInterestTag, getUserById } from "~/models/user.server";
 import { requireUser } from "~/services/auth.server";
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  await requireUser(request);
-  return {};
+  const user = await requireUser(request);
+  // #修正: ユーザーが現在持っているタグを取得してクライアントに渡す
+  const userWithTags = await getUserById(user.id);
+  const currentTags = userWithTags?.InterestTag.map((t) => t.tag) || [];
+
+  return { currentTags };
 }
 
 export async function action({ request }: ActionFunctionArgs) {
@@ -29,11 +34,14 @@ export async function action({ request }: ActionFunctionArgs) {
   // 選択されたすべての "tags" の値を配列として取得
   const tags = formData.getAll("tags") as string[];
 
+  // addInterestTag内で 'set' を使うようになったため、これでリセットと更新が同時に行われる
   await addInterestTag(user.id, tags);
   return redirect("/mypage");
 }
 
 export default function EditInterestTagsPage() {
+  // #修正: loaderから現在のタグリストを取得
+  const { currentTags } = useLoaderData<typeof loader>();
   return (
     <Box
       maxW="400px"
@@ -57,11 +65,16 @@ export default function EditInterestTagsPage() {
             maxH="300px"
             overflowY="auto"
           >
-            {/* 修正点1: spacing -> gap に変更 */}
+            {/*  spacing -> gap に変更 */}
             <SimpleGrid columns={2} gap={3}>
               {Array.from(farmKeyword).map((tag) => (
-                // 修正点2: v3用のカスタムCheckboxコンポーネントを使用
-                <CustomCheckbox key={tag} value={tag} label={tag} />
+                //  v3用のカスタムCheckboxコンポーネントを使用
+                <CustomCheckbox
+                  key={tag}
+                  value={tag}
+                  label={tag}
+                  defaultChecked={currentTags.includes(tag)}
+                />
               ))}
             </SimpleGrid>
           </Box>
@@ -83,9 +96,22 @@ export default function EditInterestTagsPage() {
 // ------------------------------------------
 // Chakra UI v3 用のチェックボックス部品
 // ------------------------------------------
-function CustomCheckbox({ value, label }: { value: string; label: string }) {
+function CustomCheckbox({
+  value,
+  label,
+  defaultChecked,
+}: {
+  value: string;
+  label: string;
+  defaultChecked: boolean;
+}) {
   return (
-    <Checkbox.Root name="tags" value={value} colorPalette="teal">
+    <Checkbox.Root
+      name="tags"
+      value={value}
+      colorPalette="teal"
+      defaultChecked={defaultChecked}
+    >
       <Checkbox.HiddenInput />
       <Checkbox.Control>
         {/* チェックが入ったときのアイコン（チェックマーク） */}

--- a/app/routes/user/mypage.tsx
+++ b/app/routes/user/mypage.tsx
@@ -11,6 +11,8 @@ import {
   VStack,
   Separator,
   Field,
+  Badge,
+  Flex,
 } from "@chakra-ui/react";
 import {
   Calendar,
@@ -22,6 +24,7 @@ import {
   X,
   Building2,
   Tractor,
+  Tag,
 } from "lucide-react";
 import { useEffect, useState } from "react";
 import {
@@ -34,6 +37,7 @@ import {
   type LoaderFunctionArgs,
 } from "react-router";
 
+import { prisma } from "~/lib/prisma";
 import { getFarmsByUserId } from "~/models/farm.server";
 import { getOrganizationsByUserId } from "~/models/organization.server";
 import { updateUser } from "~/models/user.server";
@@ -43,10 +47,19 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const user = await requireUser(request);
   const organizations = await getOrganizationsByUserId(user.id);
   const farms = await getFarmsByUserId(user.id);
+
+  //ユーザーの興味タグを取得
+  const userWithTags = await prisma.user.findUnique({
+    where: { id: user.id },
+    select: { InterestTag: true },
+  });
+  const interestTags = userWithTags?.InterestTag ?? [];
+
   if (!user) {
     return redirect("/login");
   }
-  return { user, organizations, farms };
+  // (#修正) interestTags を返却データに追加
+  return { user, organizations, farms, interestTags };
 }
 
 export async function action({ request }: ActionFunctionArgs) {
@@ -117,7 +130,9 @@ const InfoRow = ({
 };
 
 export default function Mypage() {
-  const { user, organizations, farms } = useLoaderData<typeof loader>();
+  // interestTags を受け取る
+  const { user, organizations, farms, interestTags } =
+    useLoaderData<typeof loader>();
   const actionData = useActionData<typeof action>();
   const [isEditing, setIsEditing] = useState(!!actionData?.errors);
   const [data, setData] = useState({
@@ -341,6 +356,54 @@ export default function Mypage() {
                     </Link>
                   ))}
                 </VStack>
+              )}
+            </VStack>
+          </Box>
+
+          {/* 興味・関心セクション*/}
+          <Box
+            p={6}
+            borderWidth="1px"
+            borderRadius="lg"
+            boxShadow="md"
+            bg="white"
+          >
+            <VStack align="stretch" gap={4}>
+              <HStack justify="space-between">
+                <HStack>
+                  <Icon as={Tag} color="teal.500" boxSize={6} />
+                  <Heading size="md">あなたの興味</Heading>
+                </HStack>
+                {/* routes.tsに基づき /edit-interest-tags へリンク */}
+                <Link to="/edit-interest-tags">
+                  <Button colorScheme="teal" size="sm">
+                    興味を追加
+                  </Button>
+                </Link>
+              </HStack>
+
+              <Separator />
+
+              {interestTags.length === 0 ? (
+                <Text color="gray.500" py={2}>
+                  登録されている興味はありません。
+                </Text>
+              ) : (
+                <Flex gap={2} wrap="wrap">
+                  {interestTags.map((tag) => (
+                    <Badge
+                      key={tag.id}
+                      colorScheme="teal"
+                      variant="subtle"
+                      px={2}
+                      py={1}
+                      borderRadius="full"
+                      fontSize="sm"
+                    >
+                      {tag.tag}
+                    </Badge>
+                  ))}
+                </Flex>
               )}
             </VStack>
           </Box>


### PR DESCRIPTION
マイページにおいて、所属組織の下にユーザの興味を登録してもらうページで登録したもらったタグを表示する「あなたの興味」という欄を追加しました。その欄の横にある「興味を追加」というボタンを押してもらうと興味登録ページに飛ぶことが出来ます。また、登録してもらったタグの削除や変更ができないことにより、興味がなくなったタグなどを削除することができないなどの問題を解決するために、すでに登録してあるタグには興味登録ページのタグのチェックリストにすでにチェックが入っているようにし、そのチェックを外したり、新たに追加したりして、「保存する」のボタンを押してもらうことでそのときチェックがついていたタグで新たにInterestTagsが更新されるようにしました。